### PR TITLE
stop using rootUrl to fix netlify previews and deployments

### DIFF
--- a/config/environment.js
+++ b/config/environment.js
@@ -47,6 +47,7 @@ module.exports = function (environment) {
   }
 
   if (environment === 'production') {
+    // production config
   }
 
   return ENV;

--- a/config/environment.js
+++ b/config/environment.js
@@ -47,8 +47,6 @@ module.exports = function (environment) {
   }
 
   if (environment === 'production') {
-    ENV.rootURL = '/ember-data-request-service-cheat-sheet';
-    ENV.locationType = 'hash';
   }
 
   return ENV;


### PR DESCRIPTION
It's not possible to use neflity and github pages at the same time, we should use netlify if we're using netlify 👍 