### PR TITLE
Fix ember data request service link

### DIFF
--- a/translations/de-de.yaml
+++ b/translations/de-de.yaml
@@ -3,7 +3,7 @@ layout:
     logo-alt-text: 'EmberData Request Service Spickzettel'
     title: EmberData Request Service Spickzettel
     description-1: >
-      Dieser Leitfaden ist ein Spickzettel für die Verwendung des '<a href="https://emberjs.com/editions/octane" target="_blank" rel="noopener noreferrer">EmberData-Anforderungsdienstes</a>'.
+      Dieser Leitfaden ist ein Spickzettel für die Verwendung des '<a href="https://api.emberjs.com/ember-data/release/modules/@ember-data%2Frequest" target="_blank" rel="noopener noreferrer">EmberData-Anforderungsdienstes</a>'.
       Es deckt nicht alles ab, aber es sollte Ihnen den Einstieg erleichtern!
       PRs sind willkommen im '<a href="https://github.com/ember-learn/ember-data-request-service-cheat-sheet" target="_blank" rel="noopener noreferrer">'GitHub-Repository'</a>'.
     description-2: >

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -3,7 +3,7 @@ layout:
     logo-alt-text: 'EmberData Request Service Cheat Sheet'
     title: EmberData Request Service Cheat Sheet
     description-1: >
-      This guide is a cheat sheet for using '<a href="https://emberjs.com/editions/octane" target="_blank" rel="noopener noreferrer">EmberData&#39;s Request Service</a>'.
+      This guide is a cheat sheet for using '<a href="https://api.emberjs.com/ember-data/release/modules/@ember-data%2Frequest" target="_blank" rel="noopener noreferrer">EmberData&#39;s Request Service</a>'.
       It doesn't cover everything, but it should get you started!
       PRs welcome at '<a href="https://github.com/ember-learn/ember-data-request-service-cheat-sheet" target="_blank" rel="noopener noreferrer">'the GitHub repository'</a>'.
     description-2: >

--- a/translations/es.yaml
+++ b/translations/es.yaml
@@ -3,7 +3,7 @@ layout:
     logo-alt-text: 'EmberData Request Service Cheat Sheet'
     title: Hoja de trucos del servicio de solicitud de EmberData
     description-1: >
-      Esta guía es una hoja de trucos para usar el '<a href="https://emberjs.com/editions/octane" target="_blank" rel="noopener noreferrer">Servicio de solicitud de EmberData</a>'.
+      Esta guía es una hoja de trucos para usar el '<a href="https://api.emberjs.com/ember-data/release/modules/@ember-data%2Frequest" target="_blank" rel="noopener noreferrer">Servicio de solicitud de EmberData</a>'.
       No cubre todo, ¡pero te ayudará a empezar!
       Se aceptan PRs en '<a href="https://github.com/ember-learn/ember-data-request-service-cheat-sheet" target="_blank" rel="noopener noreferrer">'el repositorio de GitHub'</a>'.
     description-2: >

--- a/translations/fr-fr.yaml
+++ b/translations/fr-fr.yaml
@@ -3,7 +3,7 @@ layout:
     logo-alt-text: 'Feuille de triche du service de demande EmberData'
     title: Feuille de triche du service de demande EmberData
     description-1: >
-      Ce guide est une feuille de triche pour utiliser le '<a href="https://emberjs.com/editions/octane" target="_blank" rel="noopener noreferrer">service de demande EmberData</a>'.
+      Ce guide est une feuille de triche pour utiliser le '<a href="https://api.emberjs.com/ember-data/release/modules/@ember-data%2Frequest" target="_blank" rel="noopener noreferrer">service de demande EmberData</a>'.
       Il ne couvre pas tout, mais cela devrait vous aider à démarrer!
       Les PR sont les bienvenus sur '<a href="https://github.com/ember-learn/ember-data-request-service-cheat-sheet" target="_blank" rel="noopener noreferrer">'le dépôt GitHub'</a>'.
     description-2: >

--- a/translations/ja.yaml
+++ b/translations/ja.yaml
@@ -3,7 +3,7 @@ layout:
     logo-alt-text: 'EmberData リクエストサービス チートシート'
     title: EmberData リクエストサービス チートシート
     description-1: >
-      このガイドは、'<a href="https://emberjs.com/editions/octane" target="_blank" rel="noopener noreferrer">EmberDataのリクエストサービス</a>'の使用に関するチートシートです。
+      このガイドは、'<a href="https://api.emberjs.com/ember-data/release/modules/@ember-data%2Frequest" target="_blank" rel="noopener noreferrer">EmberDataのリクエストサービス</a>'の使用に関するチートシートです。
       すべてを網羅しているわけではありませんが、スタートするのに役立つでしょう！
       '<a href="https://github.com/ember-learn/ember-data-request-service-cheat-sheet" target="_blank" rel="noopener noreferrer">GitHubリポジトリ</a>'でのPRは歓迎です。
     description-2: >

--- a/translations/pt-br.yaml
+++ b/translations/pt-br.yaml
@@ -3,7 +3,7 @@ layout:
     logo-alt-text: 'EmberData Request Service Cheat Sheet'
     title: EmberData Request Service Cheat Sheet
     description-1: >
-      Este guia é um resumo para usar o '<a href="https://emberjs.com/editions/octane" target="_blank" rel="noopener noreferrer">Serviço de Requisição do EmberData</a>'.
+      Este guia é um resumo para usar o '<a href="https://api.emberjs.com/ember-data/release/modules/@ember-data%2Frequest" target="_blank" rel="noopener noreferrer">Serviço de Requisição do EmberData</a>'.
       Não cobre tudo, mas deve te ajudar a começar!
       Contribuições são bem-vindas no '<a href="https://github.com/ember-learn/ember-data-request-service-cheat-sheet" target="_blank" rel="noopener noreferrer">'repositório do GitHub'</a>'.
     description-2: >


### PR DESCRIPTION
This link is pointing to the ember octane page which is probably not intended. Wasn't sure which url should be used and figured that `https://api.emberjs.com/ember-data/release/modules/@ember-data%2Frequest` is probably the best page to link. I'm happy to use a different url if there is a better place to link to, please let me know.

Possible other links I've considered:

* https://api.emberjs.com/ember-data/release/modules/@ember-data%2Fstore
* https://github.com/emberjs/data/tree/main/packages/store