### PR TITLE
Update handler.js to allow access to MUTATION_OPS

### DIFF
--- a/snippets/updating-data/create-record/handler.js
+++ b/snippets/updating-data/create-record/handler.js
@@ -2,9 +2,10 @@
 import { recordIdentifierFor } from '@ember-data/store';
 import { serializeResources } from '@ember-data/json-api/request';
 
-const updatesHandler = {
-  MUTATION_OPS: new Set(['createRecord', 'updateRecord']),
+const MUTATION_OPS = new Set(['createRecord', 'updateRecord']);
 
+
+const updatesHandler = {
   request(context, next) {
     if (!MUTATION_OPS.has(context.request.op)) {
       // Not a mutation, do nothing


### PR DESCRIPTION
This moves mutation ops to a constant outside the object. The original example will result in MUTATION_OPS not found.

---

This pull request refactors the `updatesHandler` in `snippets/updating-data/create-record/handler.js` to improve code clarity by separating the `MUTATION_OPS` constant from the `updatesHandler` object.

Code clarity improvements:

* [`snippets/updating-data/create-record/handler.js`](diffhunk://#diff-8a1d41d4285a433b8a2e581dbb087e11635cc607e9ae8fc432aed6af695a0d0cL5-R8): Extracted the `MUTATION_OPS` constant from the `updatesHandler` object and defined it as a standalone constant, making the code easier to read and maintain.